### PR TITLE
feat: support for toggling admin/redirect app

### DIFF
--- a/.docker/.env.example
+++ b/.docker/.env.example
@@ -15,3 +15,7 @@ DATABASE_URL=postgres://root:root@tirehtoori-db:5432/tirehtoori
 SECRET_KEY=QfxRQSWdiPDJuJau7ZHbTXWLOa5FmTZS
 ALLOWED_HOSTS=*
 STATIC_URL=/__static/
+
+# Enable/disable apps
+ENABLE_ADMIN_APP=True
+ENABLE_REDIRECT_APP=True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       SECRET_KEY: topsecret123
       DATABASE_URL: postgres://tirehtoori:tirehtoori@localhost:5432/tirehtoori
       PYTHON_VERSION: 3.11
+      ENABLE_ADMIN_APP: true
+      ENABLE_REDIRECT_APP: true
 
     services:
       postgres:

--- a/tirehtoori/api.py
+++ b/tirehtoori/api.py
@@ -1,7 +1,9 @@
+from django.conf import settings
 from ninja import NinjaAPI
-
-from redirect.api import router as redirect_router
 
 api = NinjaAPI()
 
-api.add_router("/", redirect_router)
+if settings.ENABLE_REDIRECT_APP:
+    from redirect.api import router as redirect_router
+
+    api.add_router("/", redirect_router)

--- a/tirehtoori/settings.py
+++ b/tirehtoori/settings.py
@@ -20,6 +20,8 @@ env = environ.Env(
     DATABASE_PASSWORD=(str, ""),
     DJANGO_LOG_LEVEL=(str, "INFO"),
     DEBUG=(bool, False),
+    ENABLE_REDIRECT_APP=(bool, False),
+    ENABLE_ADMIN_APP=(bool, False),
     SECRET_KEY=(str, ""),
     SENTRY_DSN=(str, ""),
     SENTRY_ENVIRONMENT=(str, "development"),
@@ -73,6 +75,9 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
 ]
+
+if not env("ENABLE_ADMIN_APP"):
+    INSTALLED_APPS.pop(INSTALLED_APPS.index("django.contrib.admin"))
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -154,3 +159,9 @@ STATIC_URL = env("STATIC_URL")
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Enable Django Admin site
+ENABLE_ADMIN_APP = env("ENABLE_ADMIN_APP")
+
+# Enable API
+ENABLE_REDIRECT_APP = env("ENABLE_REDIRECT_APP")

--- a/tirehtoori/test_settings.py
+++ b/tirehtoori/test_settings.py
@@ -1,3 +1,5 @@
 from .settings import *  # noqa
 
 ALLOWED_HOSTS = ["*"]
+ENABLE_REDIRECT_APP = True
+ENABLE_ADMIN_APP = True

--- a/tirehtoori/urls.py
+++ b/tirehtoori/urls.py
@@ -15,12 +15,16 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from django.conf import settings
 from django.contrib import admin
 from django.urls import path
 
 from .api import api
 
-urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("", api.urls),
-]
+urlpatterns = []
+
+if settings.ENABLE_ADMIN_APP:
+    urlpatterns.append(path("admin/", admin.site.urls))
+
+if settings.ENABLE_REDIRECT_APP:
+    urlpatterns.append(path("", api.urls))


### PR DESCRIPTION
Allows enabling and disabling the admin and redirect app with their corresponding settings.

The motivation for this is to be able to have separate instances for the admin app and the redirect app.