### PR TITLE
test: add UniqueFaker variation of factory.Faker

### DIFF
--- a/redirect/tests/test_utils.py
+++ b/redirect/tests/test_utils.py
@@ -1,0 +1,21 @@
+from redirect.factories import UniqueFaker
+
+
+def test_unique_faker():
+    # Not a very deterministic test, but thanks to birthday paradox, it should
+    # be very unlikely to give a false positive if the implementation is incorrect.
+    faker_field = UniqueFaker("random_int")
+    used_values = set()
+    for _ in range(10000):
+        # As of 2024-10-17, UniqueFaker (or, rather, faker.proxy.UniqueProxy) attempts
+        # to generate a unique value up to 1000 times, so the random range is
+        # intentionally set to a larger range than the number of iterations to reduce
+        # the chance of false negatives.
+        # The very final step actually has a very large chance of *not* being unique
+        # (~91% since 9999 out of 11000 numbers are already in use), but since it's
+        # repeated 1000 times, the chance of a false negative becomes virtually zero.
+        value = faker_field.evaluate(
+            None, None, {"locale": "en_US", "min": 1, "max": 11000}
+        )
+        assert value not in used_values
+        used_values.add(value)

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,7 @@
 -c requirements.txt
-factory_boy
+# NOTE: factory_boy version pinned because redirect.factories.UniqueFaker uses factory_boy internals.
+# Future versions might break the code (or replace it with a built-in solution).
+factory_boy==3.3.1
 pytest
 pytest-django
 pytest-factoryboy


### PR DESCRIPTION
For unique fields. Tests can (and did, at least once) fail because of duplicate values generated by Faker, even if it's not very likely.

The test for UniqueFaker is not very deterministic, and while you could do a random int between 1 and 10 000 and get the value 10 000 times to more or less guarantee that the values are unique, the problem is how Faker's UniqueProxy works. It generates a random value, compares it to a list of previously generated values, and if found, it attempts this again (up to 1 000 times). So, funnily enough, having a very strict range of values makes the test more likely to give a false negative while a very lax range increases the chances of a false positive.