### PR TITLE
Add implementation for case-sensitivity, fix wildcard match bug

### DIFF
--- a/redirect/api.py
+++ b/redirect/api.py
@@ -30,13 +30,21 @@ def get_domain_rule_or_404(domain, path) -> RedirectRule:
 
 def find_wildcard_rule(domain, path) -> RedirectRule | None:
     cleaned_path = path.strip("/")
+    split_cleaned_path = cleaned_path.split("/") if cleaned_path else []
+
     wildcard_redirects = RedirectRule.objects.filter(domain=domain, match_subpaths=True)
     for wildcard_rule in wildcard_redirects:
-        if wildcard_rule.case_sensitive and cleaned_path.startswith(wildcard_rule.path):
-            return wildcard_rule
-        if not wildcard_rule.case_sensitive and cleaned_path.lower().startswith(
-            wildcard_rule.path.lower()
-        ):
+        split_wildcard_path = (
+            wildcard_rule.path.split("/") if wildcard_rule.path else []
+        )
+        if len(split_wildcard_path) > len(split_cleaned_path):
+            continue
+
+        if not wildcard_rule.case_sensitive:
+            split_cleaned_path = [part.lower() for part in split_cleaned_path]
+            split_wildcard_path = [part.lower() for part in split_wildcard_path]
+
+        if split_cleaned_path[: len(split_wildcard_path)] == split_wildcard_path:
             return wildcard_rule
 
     return None

--- a/redirect/models.py
+++ b/redirect/models.py
@@ -154,9 +154,13 @@ class RedirectRule(TimestampedModel):
                 # No conflicts with itself, e.g. when updating an existing rule
                 continue
 
-            if self.path.startswith(f"{rule.path}/") or rule.path.startswith(
-                f"{self.path}/"
-            ):
+            if self.case_sensitive and rule.case_sensitive:
+                a = self.path
+                b = rule.path
+            else:
+                a = self.path.lower()
+                b = rule.path.lower()
+            if a.startswith(f"{b}/") or b.startswith(f"{a}/"):
                 raise ValidationError(
                     f"Path {self.path} conflicts with existing rule {rule.path}"
                 )

--- a/redirect/tests/test_api.py
+++ b/redirect/tests/test_api.py
@@ -5,16 +5,6 @@ from django.test import Client
 from redirect.api import find_wildcard_rule, get_domain_rule_or_404
 
 
-@pytest.fixture
-def domain_client(client, domain):
-    """
-    An instance of the Django test client with HTTP_HOST set to the domain name
-    of the default domain fixture.
-    """
-    client.defaults["HTTP_HOST"] = domain.names.first().name
-    return client
-
-
 @pytest.mark.django_db
 def test_domain_rule_exact_match(domain, redirect_rule_factory):
     expected_rule = redirect_rule_factory(
@@ -73,193 +63,184 @@ def test_find_wildcard_rule_case_insensitive_match(domain, redirect_rule_factory
     assert result == expected_rule
 
 
-@pytest.mark.parametrize("path", ["foo", "foo/bar", "foo/bar/baz"])
 @pytest.mark.django_db
-def test_redirect_valid_path(
-    domain_client: Client, domain, redirect_rule_factory, path
-):
-    rule = redirect_rule_factory(path=path, domain=domain)
+class TestRedirectView:
+    @pytest.fixture
+    def domain_client(self, client, domain):
+        """
+        An instance of the Django test client with HTTP_HOST set to the domain name
+        of the default domain fixture.
+        """
+        client.defaults["HTTP_HOST"] = domain.names.first().name
+        return client
 
-    response = domain_client.get(f"/{path}")
+    @pytest.mark.parametrize("path", ["foo", "foo/bar", "foo/bar/baz"])
+    def test_redirect_valid_path(
+        self, domain_client: Client, domain, redirect_rule_factory, path
+    ):
+        rule = redirect_rule_factory(path=path, domain=domain)
 
-    assert response.status_code == 302
-    assert response["Location"] == rule.destination
+        response = domain_client.get(f"/{path}")
 
+        assert response.status_code == 302
+        assert response["Location"] == rule.destination
 
-@pytest.mark.django_db
-def test_redirect_valid_path_permanent(
-    domain_client: Client, domain, redirect_rule_factory
-):
-    rule = redirect_rule_factory(
-        path="foo",
-        permanent=True,
-        domain=domain,
+    def test_redirect_valid_path_permanent(
+        self, domain_client: Client, domain, redirect_rule_factory
+    ):
+        rule = redirect_rule_factory(
+            path="foo",
+            permanent=True,
+            domain=domain,
+        )
+
+        response = domain_client.get("/foo")
+
+        assert response.status_code == 301
+        assert response["Location"] == rule.destination
+
+    def test_redirect_valid_path_case_insensitive(
+        self, domain_client: Client, domain, redirect_rule_factory
+    ):
+        rule = redirect_rule_factory(
+            path="foo",
+            domain=domain,
+            case_sensitive=False,
+        )
+
+        response = domain_client.get("/FOO")
+
+        assert response.status_code == 302
+        assert response["Location"] == rule.destination
+
+    def test_redirect_valid_path_case_sensitive(
+        self, domain_client: Client, domain, redirect_rule_factory
+    ):
+        redirect_rule_factory(
+            path="foo",
+            domain=domain,
+            case_sensitive=True,
+        )
+
+        response = domain_client.get("/FOO")
+
+        assert response.status_code == 404
+
+        response = domain_client.get("/foo")
+
+        assert response.status_code == 302
+
+    def test_redirect_valid_path_multiple_domain_names(
+        self, client: Client, domain_factory, redirect_rule_factory
+    ):
+        domain_names = ["acme.test", "www.acme.test"]
+        domain = domain_factory(display_name="ACME Inc.", names=domain_names)
+        rule = redirect_rule_factory(path="foo", domain=domain)
+
+        response_1 = client.get("/foo", HTTP_HOST=domain_names[0])
+        response_2 = client.get("/foo", HTTP_HOST=domain_names[1])
+
+        # Both should redirect to the same destination
+        assert response_1.status_code == response_2.status_code == 302
+        assert response_1["Location"] == response_2["Location"] == rule.destination
+
+    def test_redirect_from_root_path(
+        self, domain_client: Client, domain, redirect_rule_factory
+    ):
+        rule = redirect_rule_factory(path="", domain=domain)
+
+        response = domain_client.get("/")
+
+        assert response.status_code == 302
+        assert response["Location"] == rule.destination
+
+    def test_redirect_invalid_path(
+        self, domain_client: Client, domain, redirect_rule_factory
+    ):
+        redirect_rule_factory(path="foo", domain=domain)
+
+        response = domain_client.get("/bar")
+
+        assert response.status_code == 404
+
+    def test_redirect_invalid_domain(
+        self, client: Client, domain_factory, redirect_rule_factory
+    ):
+        domain = domain_factory(display_name="example.com")
+        redirect_rule_factory(path="foo", domain=domain)
+
+        response = client.get("/foo", HTTP_HOST="404.com")
+
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize("query_string", ["?param=value", "?param=value&foo=bar"])
+    def test_redirect_with_pass_query_string_should_append_query_string(
+        self, domain_client: Client, domain, redirect_rule_factory, query_string
+    ):
+        rule = redirect_rule_factory(path="foo", domain=domain, pass_query_string=True)
+
+        response = domain_client.get(f"/foo{query_string}")
+
+        assert response.status_code == 302
+        assert response["Location"] == f"{rule.destination}{query_string}"
+
+    def test_redirect_with_empty_query_string_should_discard_query_string(
+        self, domain_client: Client, domain, redirect_rule_factory
+    ):
+        rule = redirect_rule_factory(path="foo", domain=domain, pass_query_string=True)
+
+        response = domain_client.get("/foo?")
+
+        assert response.status_code == 302
+        assert response["Location"] == rule.destination
+
+    @pytest.mark.parametrize(
+        "subpath",
+        [
+            "",
+            "bar",
+            "bar/baz",
+            "bar/baz/lorem/ipsum/dolor/sit/amet/consectetur/adipiscing/elit",
+        ],
     )
+    def test_redirect_with_match_sub_paths_should_redirect_subpaths(
+        self, domain_client: Client, domain, redirect_rule_factory, subpath
+    ):
+        rule = redirect_rule_factory(path="foo", domain=domain, match_subpaths=True)
 
-    response = domain_client.get("/foo")
+        response = domain_client.get(f"/foo{subpath}")
 
-    assert response.status_code == 301
-    assert response["Location"] == rule.destination
+        assert response.status_code == 302
+        assert response["Location"] == rule.destination
 
-
-@pytest.mark.django_db
-def test_redirect_valid_path_case_insensitive(
-    domain_client: Client, domain, redirect_rule_factory
-):
-    rule = redirect_rule_factory(
-        path="foo",
-        domain=domain,
-        case_sensitive=False,
+    @pytest.mark.parametrize(
+        "subpath",
+        [
+            "",
+            "bar",
+            "bar/baz",
+            "bar/baz/lorem/ipsum/dolor/sit/amet/consectetur/adipiscing/elit",
+        ],
     )
+    def test_redirect_with_pass_sub_paths_should_append_subpath_to_destination(
+        self, domain_client: Client, domain, redirect_rule_factory, subpath
+    ):
+        rule = redirect_rule_factory(
+            path="foo", domain=domain, match_subpaths=True, append_subpath=True
+        )
 
-    response = domain_client.get("/FOO")
+        response = domain_client.get(f"/foo/{subpath}")
 
-    assert response.status_code == 302
-    assert response["Location"] == rule.destination
+        assert response.status_code == 302
+        assert response["Location"] == f"{rule.destination}{subpath}"
 
+    def test_redirect_with_exact_match_takes_precedence_over_subpaths(
+        self, domain_client: Client, domain, redirect_rule_factory
+    ):
+        exact_rule = redirect_rule_factory(path="foo/bar", domain=domain)
+        redirect_rule_factory(path="foo", domain=domain, match_subpaths=True)
 
-@pytest.mark.xfail(reason="Case sensitive paths are not supported")
-@pytest.mark.django_db
-def test_redirect_valid_path_case_sensitive(
-    domain_client: Client, domain, redirect_rule_factory
-):
-    redirect_rule_factory(
-        path="foo",
-        domain=domain,
-        case_sensitive=True,
-    )
+        response = domain_client.get("/foo/bar")
 
-    response = domain_client.get("/FOO")
-
-    assert response.status_code == 404
-
-    response = domain_client.get("/foo")
-
-    assert response.status_code == 302
-
-
-@pytest.mark.django_db
-def test_redirect_valid_path_multiple_domain_names(
-    client: Client, domain_factory, redirect_rule_factory
-):
-    domain_names = ["acme.test", "www.acme.test"]
-    domain = domain_factory(display_name="ACME Inc.", names=domain_names)
-    rule = redirect_rule_factory(path="foo", domain=domain)
-
-    response_1 = client.get("/foo", HTTP_HOST=domain_names[0])
-    response_2 = client.get("/foo", HTTP_HOST=domain_names[1])
-
-    # Both should redirect to the same destination
-    assert response_1.status_code == response_2.status_code == 302
-    assert response_1["Location"] == response_2["Location"] == rule.destination
-
-
-@pytest.mark.django_db
-def test_redirect_from_root_path(domain_client: Client, domain, redirect_rule_factory):
-    rule = redirect_rule_factory(path="", domain=domain)
-
-    response = domain_client.get("/")
-
-    assert response.status_code == 302
-    assert response["Location"] == rule.destination
-
-
-@pytest.mark.django_db
-def test_redirect_invalid_path(domain_client: Client, domain, redirect_rule_factory):
-    redirect_rule_factory(path="foo", domain=domain)
-
-    response = domain_client.get("/bar")
-
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-def test_redirect_invalid_domain(client: Client, domain_factory, redirect_rule_factory):
-    domain = domain_factory(display_name="example.com")
-    redirect_rule_factory(path="foo", domain=domain)
-
-    response = client.get("/foo", HTTP_HOST="404.com")
-
-    assert response.status_code == 404
-
-
-@pytest.mark.parametrize("query_string", ["?param=value", "?param=value&foo=bar"])
-@pytest.mark.django_db
-def test_redirect_with_pass_query_string_should_append_query_string(
-    domain_client: Client, domain, redirect_rule_factory, query_string
-):
-    rule = redirect_rule_factory(path="foo", domain=domain, pass_query_string=True)
-
-    response = domain_client.get(f"/foo{query_string}")
-
-    assert response.status_code == 302
-    assert response["Location"] == f"{rule.destination}{query_string}"
-
-
-@pytest.mark.django_db
-def test_redirect_with_empty_query_string_should_discard_query_string(
-    domain_client: Client, domain, redirect_rule_factory
-):
-    rule = redirect_rule_factory(path="foo", domain=domain, pass_query_string=True)
-
-    response = domain_client.get("/foo?")
-
-    assert response.status_code == 302
-    assert response["Location"] == rule.destination
-
-
-@pytest.mark.parametrize(
-    "subpath",
-    [
-        "",
-        "bar",
-        "bar/baz",
-        "bar/baz/lorem/ipsum/dolor/sit/amet/consectetur/adipiscing/elit",
-    ],
-)
-@pytest.mark.django_db
-def test_redirect_with_match_sub_paths_should_redirect_subpaths(
-    domain_client: Client, domain, redirect_rule_factory, subpath
-):
-    rule = redirect_rule_factory(path="foo", domain=domain, match_subpaths=True)
-
-    response = domain_client.get(f"/foo{subpath}")
-
-    assert response.status_code == 302
-    assert response["Location"] == rule.destination
-
-
-@pytest.mark.parametrize(
-    "subpath",
-    [
-        "",
-        "bar",
-        "bar/baz",
-        "bar/baz/lorem/ipsum/dolor/sit/amet/consectetur/adipiscing/elit",
-    ],
-)
-@pytest.mark.django_db
-def test_redirect_with_pass_sub_paths_should_append_subpath_to_destination(
-    domain_client: Client, domain, redirect_rule_factory, subpath
-):
-    rule = redirect_rule_factory(
-        path="foo", domain=domain, match_subpaths=True, append_subpath=True
-    )
-
-    response = domain_client.get(f"/foo/{subpath}")
-
-    assert response.status_code == 302
-    assert response["Location"] == f"{rule.destination}{subpath}"
-
-
-@pytest.mark.django_db
-def test_redirect_with_exact_match_takes_precedence_over_subpaths(
-    domain_client: Client, domain, redirect_rule_factory
-):
-    exact_rule = redirect_rule_factory(path="foo/bar", domain=domain)
-    redirect_rule_factory(path="foo", domain=domain, match_subpaths=True)
-
-    response = domain_client.get("/foo/bar")
-
-    assert response.status_code == 302
-    assert response["Location"] == exact_rule.destination
+        assert response.status_code == 302
+        assert response["Location"] == exact_rule.destination


### PR DESCRIPTION
- Factor in case sensitivity in path validation
- Factor in case sensitivity in match subpath validation
- Add case sensitivity logic in redirect endpoint
- Try to find the correct redirect rule in the following order:
  1. Exact match
  2. Case insensitive match
  3. Wildcard rule match (case sensitivity doesn't matter)
- Fix a bug with wildcard matching (e.g. `/fooooo/` matched with `/foo/(.*)`)