### PR TITLE
Add new rules for ruff linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,38 @@
 DJANGO_SETTINGS_MODULE = "tirehtoori.test_settings"
 
 [tool.ruff]
+target-version = "py311"
 lint.select = [
     # Pyflakes
     "F",
-    # Pycodestyle
+    # pyupgrade
+    "UP",
+    # pycodestyle
     "E",
     "W",
+    # flake8-bandit
+    "S",
+    # flake8-boolean-trap
+    "FBT",
+    # flake8-bugbear
+    "B",
+    # flake8-comprehensions
+    "C4",
+    # flake8-django
+    "DJ",
+    # flake8-gettext
+    "INT",
+    # flake8-pie
+    "PIE",
+    # flake8-print
+    "T20",
+    # flake8-simplify
+    "SIM",
+    # pep8-naming
+    "N",
+    # pygrep-hooks
+    "PGH",
     # isort
     "I001"
 ]
+lint.extend-per-file-ignores = { "*/migrations/*" = ["E501"], "*/tests/*" = ["E501", "S101"] }

--- a/redirect/management/commands/import_redirect_rules.py
+++ b/redirect/management/commands/import_redirect_rules.py
@@ -23,11 +23,11 @@ class ImporterError(Exception):
     pass
 
 
-class DryRunException(Exception):
+class DryRunException(Exception):  # noqa: N818
     pass
 
 
-class SkipIteration(Exception):
+class SkipIteration(Exception):  # noqa: N818
     """Used for flow control in nested loops"""
 
 
@@ -47,7 +47,7 @@ class Command(BaseCommand):
 
     def __init__(self):
         super().__init__()
-        self.force: bool = NOT_SET  # noqa
+        self.force: bool = NOT_SET
         self.collected_errors = []
         self.rule_import_stats = Stats()
         self.domain_import_stats = Stats()
@@ -104,17 +104,17 @@ class Command(BaseCommand):
                 f"Rule for {rule['path']} already exists for domain {domain}"
             )
 
-        create_kwargs = dict(
-            domain=domain,
-            path=rule["path"],
-            destination=rule["destination"],
-            permanent=rule.get("permanent"),
-            case_sensitive=rule.get("case_sensitive"),
-            pass_query_string=rule.get("pass_query_string"),
-            match_subpaths=rule.get("match_subpaths"),
-            append_subpath=rule.get("append_subpath"),
-            notes=rule.get("notes", ""),
-        )
+        create_kwargs = {
+            "domain": domain,
+            "path": rule["path"],
+            "destination": rule["destination"],
+            "permanent": rule.get("permanent"),
+            "case_sensitive": rule.get("case_sensitive"),
+            "pass_query_string": rule.get("pass_query_string"),
+            "match_subpaths": rule.get("match_subpaths"),
+            "append_subpath": rule.get("append_subpath"),
+            "notes": rule.get("notes", ""),
+        }
         create_kwargs["notes"] = self._prepend_timestamp_note(create_kwargs["notes"])
         create_kwargs = {k: v for k, v in create_kwargs.items() if v is not None}
 
@@ -181,7 +181,7 @@ class Command(BaseCommand):
             self._warning("Running in dry-run mode")
 
         json_file = kwargs["json_file"]
-        with open(json_file, "r") as file:
+        with open(json_file) as file:
             data = json.load(file)
 
         self.domain_import_stats.total = len(data)

--- a/redirect/models.py
+++ b/redirect/models.py
@@ -108,6 +108,25 @@ class RedirectRule(TimestampedModel):
             )
         ]
 
+    def __str__(self):
+        return f"{self.domain.display_name}/{self.path} -> {self.destination}"
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        return super().save(*args, **kwargs)
+
+    def clean(self):
+        # Normalize path.
+        self.path = self.path.strip().strip("/")
+
+        if self.case_sensitive:
+            self._validate_case_sensitive_path()
+        else:
+            self._validate_case_insensitive_path()
+
+        if self.match_subpaths:
+            self._validate_match_subpaths()
+
     def _validate_case_sensitive_path(self):
         """
         Check for case-sensitive conflicts with existing rules.
@@ -164,22 +183,3 @@ class RedirectRule(TimestampedModel):
                 raise ValidationError(
                     f"Path {self.path} conflicts with existing rule {rule.path}"
                 )
-
-    def clean(self):
-        # Normalize path.
-        self.path = self.path.strip().strip("/")
-
-        if self.case_sensitive:
-            self._validate_case_sensitive_path()
-        else:
-            self._validate_case_insensitive_path()
-
-        if self.match_subpaths:
-            self._validate_match_subpaths()
-
-    def save(self, *args, **kwargs):
-        self.clean()
-        return super().save(*args, **kwargs)
-
-    def __str__(self):
-        return f"{self.domain.display_name}/{self.path} -> {self.destination}"

--- a/redirect/tests/test_import_redirect_rules.py
+++ b/redirect/tests/test_import_redirect_rules.py
@@ -31,19 +31,19 @@ def import_command():
 
 @pytest.fixture
 def simple_json():
-    with open(SIMPLE_JSON_PATH, "r") as f:
+    with open(SIMPLE_JSON_PATH) as f:
         return json.load(f)
 
 
 @pytest.fixture
 def missing_domain_names_json():
-    with open(MISSING_DOMAIN_NAMES_JSON_PATH, "r") as f:
+    with open(MISSING_DOMAIN_NAMES_JSON_PATH) as f:
         return json.load(f)
 
 
 @pytest.fixture
 def all_args_multiple_domains_json():
-    with open(ALL_ARGS_MULTIPLE_DOMAINS_JSON_PATH, "r") as f:
+    with open(ALL_ARGS_MULTIPLE_DOMAINS_JSON_PATH) as f:
         return json.load(f)
 
 

--- a/redirect/tests/test_models.py
+++ b/redirect/tests/test_models.py
@@ -62,7 +62,7 @@ class TestRedirectRule:
         )
 
         # This shouldn't be fine
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             RedirectRule.objects.create(
                 domain=domain, path="/foo", destination=self.DEFAULT_DESTINATION
             )

--- a/tirehtoori/settings.py
+++ b/tirehtoori/settings.py
@@ -124,7 +124,7 @@ if env("DATABASE_PASSWORD"):
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",  # noqa
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",  # noqa: E501
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",

--- a/tirehtoori/test_settings.py
+++ b/tirehtoori/test_settings.py
@@ -1,4 +1,4 @@
-from .settings import *  # noqa
+from .settings import *  # noqa: F403
 
 ALLOWED_HOSTS = ["*"]
 ENABLE_REDIRECT_APP = True


### PR DESCRIPTION
Following rules:
- flake-bugbear
- flake-print
- pep8-naming
- pyupgrade
- flake8-bandit
- flake8-boolean-trap
- flake8-comprehensions
- flake8-django
- flake8-gettext
- flake8-pie
- flake8-simplify
- pygrep-hooks
- ignore line-lengths in migrations, tests