### PR TITLE
fix: exclude admin url from the catch-all url

### DIFF
--- a/tirehtoori/settings.py
+++ b/tirehtoori/settings.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import environ
 
 env = environ.Env(
+    ADMIN_URL=(str, "admin"),
     ALLOWED_HOSTS=(list, []),
     DATABASE_URL=(str, "postgres:///tirehtoori-db"),
     DATABASE_PASSWORD=(str, ""),
@@ -162,6 +163,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Enable Django Admin site
 ENABLE_ADMIN_APP = env("ENABLE_ADMIN_APP")
+ADMIN_URL = env("ADMIN_URL")
 
 # Enable API
 ENABLE_REDIRECT_APP = env("ENABLE_REDIRECT_APP")


### PR DESCRIPTION
Also add an ADMIN_URL setting.

How to test:
1. Start up the container
2. Access any other path than admin to cache the root URL, e.g. localhost:8080/foo
3. Access localhost:8080/admin
4. Confirm that you get to the Django admin view (either the main panel or login view)