### PR TITLE
chore: use non-deprecated release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
google-github-actions/release-please-action is deprecated.

Refs: RATYK-46