### PR TITLE
Use common uwsgi config, update Dockerfile, address Sonarcloud issues

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -18,7 +18,7 @@ RUN dnf update -y \
     && dnf install -y \
     nmap-ncat \
     gettext \
-    && pip install -U pip setuptools wheel \
+    && pip install --only-binary :all: -U pip setuptools wheel \
     && pip install --require-hashes --no-deps --no-cache-dir -r requirements.txt \
     && pip install --require-hashes --no-deps --no-cache-dir -r requirements-prod.txt \
     && dnf clean all

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -2,55 +2,77 @@
 FROM registry.access.redhat.com/ubi9/python-312 AS appbase
 # ==============================
 
+# Branch or tag used to pull python-uwsgi-common.
+ARG UWSGI_COMMON_REF="main"
+
 USER root
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-COPY --chown=default:root requirements*.txt .
+COPY requirements.txt .
+COPY requirements-prod.txt .
 
-RUN dnf update -y && dnf install -y \
+RUN dnf update -y \
+    && dnf install -y \
     nmap-ncat \
     gettext \
     && pip install -U pip setuptools wheel \
-    && pip install --no-cache-dir -r requirements.txt \
-    && pip install --no-cache-dir -r requirements-prod.txt \
-    && mkdir -p /usr/local/lib/uwsgi/plugins \
-    && uwsgi --build-plugin https://github.com/City-of-Helsinki/uwsgi-sentry \
-    && mv sentry_plugin.so /usr/local/lib/uwsgi/plugins/ \
+    && pip install --require-hashes --no-deps --no-cache-dir -r requirements.txt \
+    && pip install --require-hashes --no-deps --no-cache-dir -r requirements-prod.txt \
     && dnf clean all
 
+# Build and copy specific python-uwsgi-common files.
+ADD https://github.com/City-of-Helsinki/python-uwsgi-common/archive/"${UWSGI_COMMON_REF}".tar.gz /usr/src/
+RUN mkdir -p /usr/src/python-uwsgi-common \
+    && tar --strip-components=1 -xzf /usr/src/"${UWSGI_COMMON_REF}".tar.gz -C /usr/src/python-uwsgi-common \
+    && mkdir /etc/uwsgi \
+    && cp /usr/src/python-uwsgi-common/uwsgi-base.ini /etc/uwsgi/ \
+    && uwsgi --build-plugin /usr/src/python-uwsgi-common \
+    && rm -rf /usr/src/"${UWSGI_COMMON_REF}".tar.gz \
+    && rm -rf /usr/src/python-uwsgi-common \
+    && uwsgi --build-plugin https://github.com/City-of-Helsinki/uwsgi-sentry \
+    && mkdir -p /usr/local/lib/uwsgi/plugins \
+    && mv sentry_plugin.so /usr/local/lib/uwsgi/plugins
+
 ENTRYPOINT ["/app/.docker/docker-entrypoint.sh"]
-EXPOSE 8000/tcp
 
 # ==============================
 FROM appbase AS development
 # ==============================
-
-COPY --chown=default:root requirements-dev.txt .
-RUN pip install --no-cache-dir -r requirements-dev.txt
+COPY requirements-dev.txt .
+RUN pip install --require-hashes --no-deps --no-cache-dir -r requirements-dev.txt
 
 ENV DEV_SERVER=True
+ENV PIP_TOOLS_CACHE_DIR="/tmp/pip-tools-cache"
 
-COPY --chown=default:root . .
+RUN groupadd -g 1000 appuser \
+    && useradd -u 1000 -g appuser -ms /bin/bash appuser \
+    && chown -R appuser:root /app
 
-USER root
+COPY --chown=appuser:root . .
+
+USER appuser
+EXPOSE 8000/tcp
 
 # ==============================
 FROM appbase AS staticbuilder
 # ==============================
 
-ENV STATIC_ROOT=/app/static
-COPY --chown=default:root . .
-RUN SECRET_KEY="only-used-for-collectstatic" ENABLE_ADMIN_APP="True"  \
+ENV STATIC_ROOT="/app/static"
+COPY . .
+
+RUN mkdir -p tirehtoori/static \
+    && SECRET_KEY="only-used-for-collectstatic" ENABLE_ADMIN_APP="True" \
     python manage.py collectstatic --noinput
 
 # ==============================
 FROM appbase AS production
 # ==============================
 
-COPY --from=staticbuilder --chown=default:root /app/static /app/static
-COPY --chown=default:root . .
+COPY --from=staticbuilder /app/static /app/static
+COPY . .
 
 USER default
+EXPOSE 8000/tcp

--- a/.docker/uwsgi.ini
+++ b/.docker/uwsgi.ini
@@ -1,5 +1,9 @@
 [uwsgi]
 # https://uwsgi-docs.readthedocs.io/en/latest/Options.html
+strict = true  # Fail if any option is unknown
+
+# Use base ini file to configure common settings
+include = /etc/uwsgi/uwsgi-base.ini
 
 http = :8000
 http-timeout = 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   common:
     uses: City-of-Helsinki/.github/.github/workflows/ci-django-api.yml@main
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
       python-version: 3.12
       postgres-major-version: 17

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,20 @@ services:
       - postgres
     container_name: tirehtoori-backend
 
+  uwsgi:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile
+      target: production
+    env_file:
+      - .docker/.env
+    ports:
+      - "8080:8000"
+    depends_on:
+      - postgres
+    container_name: tirehtoori-uwsgi
+    profiles: ["uwsgi"]
+
 volumes:
   tirehtoori-postgres-data-volume:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.pytest.ini_options]
-DJANGO_SETTINGS_MODULE = "tirehtoori.test_settings"
+DJANGO_SETTINGS_MODULE = "tirehtoori.tests.test_settings"
 
 [tool.ruff]
 target-version = "py312"

--- a/tirehtoori/tests/test_settings.py
+++ b/tirehtoori/tests/test_settings.py
@@ -1,4 +1,4 @@
-from .settings import *  # noqa: F403
+from ..settings import *  # noqa: F403
 
 ALLOWED_HOSTS = ["*"]
 ENABLE_REDIRECT_APP = True


### PR DESCRIPTION
- Use common uwsgi config
- Update Dockerfile to match Dockerfiles in other projects
  - Basically a hybrid between [linkedevents'](https://github.com/City-of-Helsinki/linkedevents/blob/11e3aa6f8fabe799ecea2d2f569462391eabc6ad/docker/django/Dockerfile) and [open-city-profile's](https://github.com/City-of-Helsinki/open-city-profile/blob/0884ffe119856ce7e140fd67f19fbd6d5dab1807/Dockerfile) Dockerfiles
- Pass only SONAR_TOKEN to common workflow
- Add uwsgi service in compose.yaml, for running an uwsgi environment locally
- Wrap variables in double quotes
- Move test_settings.py under tests
- Explicitly tell pip to expect hashes and to not install any other dependencies than the ones listed in requirements files
- Require binary only on pip/setuptools/wheel upgrade

Refs: RATYK-199